### PR TITLE
Add files 

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Module::Build;
+
+Module::Build->new(
+    'module_name'       => 'TAP::Formatter::JUnit',
+    'license'           => 'perl',
+    'dist_author'       => 'Graham TerMarsch (cpan@howlingfrog.com)',
+    'requires'          => {
+        'XML::Generator'    => 0,
+        'TAP::Harness'      => 3.12,
+        'Moose'             => 0,
+        'MooseX::NonMoose'  => 0,
+        'File::Slurp'       => 0,
+        },
+    'build_requires'    => {
+        'Test::More'        => 0,
+        'IO::Scalar'        => 0,
+        'IPC::Run'          => 0,
+        'Test::XML'         => 0,
+        },
+    )->create_build_script();

--- a/META.json
+++ b/META.json
@@ -1,0 +1,59 @@
+{
+   "abstract" : "Harness output delegate for JUnit output",
+   "author" : [
+      "Graham TerMarsch (cpan@howlingfrog.com)"
+   ],
+   "dynamic_config" : 1,
+   "generated_by" : "Module::Build version 0.4007, CPAN::Meta::Converter version 2.132140",
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "TAP-Formatter-JUnit",
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "IO::Scalar" : "0",
+            "IPC::Run" : "0",
+            "Test::More" : "0",
+            "Test::XML" : "0"
+         }
+      },
+      "configure" : {
+         "requires" : {
+            "Module::Build" : "0.40"
+         }
+      },
+      "runtime" : {
+         "requires" : {
+            "File::Slurp" : "0",
+            "Moose" : "0",
+            "MooseX::NonMoose" : "0",
+            "TAP::Harness" : "3.12",
+            "XML::Generator" : "0"
+         }
+      }
+   },
+   "provides" : {
+      "TAP::Formatter::JUnit" : {
+         "file" : "lib/TAP/Formatter/JUnit.pm",
+         "version" : "0.11"
+      },
+      "TAP::Formatter::JUnit::Result" : {
+         "file" : "lib/TAP/Formatter/JUnit/Result.pm"
+      },
+      "TAP::Formatter::JUnit::Session" : {
+         "file" : "lib/TAP/Formatter/JUnit/Session.pm"
+      }
+   },
+   "release_status" : "stable",
+   "resources" : {
+      "license" : [
+         "http://dev.perl.org/licenses/"
+      ]
+   },
+   "version" : "0.11"
+}

--- a/META.yml
+++ b/META.yml
@@ -1,0 +1,35 @@
+---
+abstract: 'Harness output delegate for JUnit output'
+author:
+  - 'Graham TerMarsch (cpan@howlingfrog.com)'
+build_requires:
+  IO::Scalar: 0
+  IPC::Run: 0
+  Test::More: 0
+  Test::XML: 0
+configure_requires:
+  Module::Build: 0.40
+dynamic_config: 1
+generated_by: 'Module::Build version 0.4007, CPAN::Meta::Converter version 2.132140'
+license: perl
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: 1.4
+name: TAP-Formatter-JUnit
+provides:
+  TAP::Formatter::JUnit:
+    file: lib/TAP/Formatter/JUnit.pm
+    version: 0.11
+  TAP::Formatter::JUnit::Result:
+    file: lib/TAP/Formatter/JUnit/Result.pm
+  TAP::Formatter::JUnit::Session:
+    file: lib/TAP/Formatter/JUnit/Session.pm
+requires:
+  File::Slurp: 0
+  Moose: 0
+  MooseX::NonMoose: 0
+  TAP::Harness: 3.12
+  XML::Generator: 0
+resources:
+  license: http://dev.perl.org/licenses/
+version: 0.11


### PR DESCRIPTION
I caught an error when I tried to install use by App::cpm. So I added some files to install use by cpm

My cpanfile is the below
```perl
requires 'perl', '5.008001';

on 'test' => sub {
    requires 'Test::More', '0.98';
    requires 'Test2::V0';
    requires 'TAP::Formatter::JUnit', git => 'https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git';
};
```

```sh
$ cpm install 
```

error

```
...
2023-07-11T14:44:27,69614,TAP::Formatter::JUnit| Resolved TAP::Formatter::JUnit (0) -> https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git from Custom
2023-07-11T14:44:27,69614,https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git| Cloning https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git
2023-07-11T14:44:27,69614,https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git| Executing git clone https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git /Users/yabuki-ryosuke/.perl-cpm/work/1689054267.69461/TAP-Formatter-JUnit-x3Zpl
2023-07-11T14:44:27,69614,https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git| Cloning into '/Users/yabuki-ryosuke/.perl-cpm/work/1689054267.69461/TAP-Formatter-JUnit-x3Zpl'...
2023-07-11T14:44:30,69614,https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git| -> OK
2023-07-11T14:44:30,69614,https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git| Distribution does not have META.json nor META.yml
2023-07-11T14:44:30,69614,https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git| Failed to fetch/configure distribution
2023-07-11T14:44:30,69461| --
2023-07-11T14:44:30,69461| Installation failed. The direct cause of the failure comes from the following packages/distributions; you may want to grep this log file by them:
2023-07-11T14:44:30,69461|  * https://github.com/shibuiwilliam/TAP-Formatter-JUnit.git
```